### PR TITLE
Export Study Area to External URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "symfony/flex": "2.8.1",
         "symfony/form": "6.4.23",
         "symfony/framework-bundle": "6.4.23",
+        "symfony/http-client": "6.4.*",
         "symfony/http-foundation": "6.4.23",
         "symfony/http-kernel": "6.4.23",
         "symfony/lock": "6.4.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "10802d0c4cfaaf161f9b054297f521da",
+    "content-hash": "01f5aec38065d1ed3ca9e171879554cb",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -7006,6 +7006,177 @@
                 }
             ],
             "time": "2025-06-26T21:24:02+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v6.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "60a113666fa67e598abace38e5f46a0954d8833d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/60a113666fa67e598abace38e5f46a0954d8833d",
+                "reference": "60a113666fa67e598abace38e5f46a0954d8833d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "~3.4.3|^3.5.1",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.3"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.5",
+                "amphp/http-client": "^4.2.1",
+                "amphp/http-tunnel": "^1.0",
+                "amphp/socket": "^1.1",
+                "guzzlehttp/promises": "^1.4|^2.0",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v6.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-27T11:52:33+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "c2f3ad828596624ca39ea40f83617ef51ca8bbf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/c2f3ad828596624ca39ea40f83617ef51ca8bbf9",
+                "reference": "c2f3ad828596624ca39ea40f83617ef51ca8bbf9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-25T12:02:18+00:00"
         },
         {
             "name": "symfony/http-foundation",

--- a/migrations/2023/07/Version20230706134822.php
+++ b/migrations/2023/07/Version20230706134822.php
@@ -14,7 +14,7 @@ final class Version20230706134822 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'export studyarea to a given url';
+        return 'Export studyarea to a given url';
     }
 
     public function up(Schema $schema): void

--- a/migrations/2023/07/Version20230706134822.php
+++ b/migrations/2023/07/Version20230706134822.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230706134822 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'export studyarea to a given url';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE study_area ADD url_export_enabled TINYINT(1) NOT NULL');
+        $this->addSql('ALTER TABLE study_area ADD export_url VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE study_area DROP url_export_enabled');
+        $this->addSql('ALTER TABLE study_area DROP export_url');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/migrations/2023/07/Version20230706134822.php
+++ b/migrations/2023/07/Version20230706134822.php
@@ -21,7 +21,7 @@ final class Version20230706134822 extends AbstractMigration
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE study_area ADD url_export_enabled TINYINT(1) NOT NULL');
-        $this->addSql('ALTER TABLE study_area ADD export_url VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE study_area ADD export_url VARCHAR(512) DEFAULT NULL');
     }
 
     public function down(Schema $schema): void

--- a/src/Controller/DataController.php
+++ b/src/Controller/DataController.php
@@ -547,7 +547,7 @@ class DataController extends AbstractController
 
   #[Route('/download')]
   #[IsGranted(StudyAreaVoter::EDIT, subject: 'requestStudyArea')]
-  public function download(Request $request, RequestStudyArea $requestStudyArea, ExportService $exportService, TranslatorInterface $translator): array|Response
+  public function download(Request $request, RequestStudyArea $requestStudyArea, TranslatorInterface $translator, ExportService $exportService): Response
   {
     $studyArea = $requestStudyArea->getStudyArea();
     $form = $this->createForm(DownloadType::class, null, [

--- a/src/Entity/StudyArea.php
+++ b/src/Entity/StudyArea.php
@@ -17,6 +17,7 @@ use Doctrine\Common\Collections\Selectable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping as ORM;
+use Drenso\Shared\Helper\StringHelper;
 use Drenso\Shared\Interfaces\IdInterface;
 use Gedmo\Mapping\Annotation as Gedmo;
 use JMS\Serializer\Annotation as JMSA;
@@ -169,6 +170,17 @@ class StudyArea implements Stringable, IdInterface
   /** @var Collection<int, StylingConfiguration> */
   #[ORM\OneToMany(mappedBy: 'studyArea', targetEntity: StylingConfiguration::class, fetch: 'EXTRA_LAZY')]
   private Collection $stylingConfigurations;
+
+  /** Setting this to true makes it possible to export studyarea to given URL endpoint. */
+  #[ORM\Column(name: 'url_export_enabled', options: ['default' => false]  )]
+  private bool $urlExportEnabled = false;
+
+  /** The URL to export the study area to. */
+  #[Assert\Url]
+  #[Assert\Length(max: 512)]
+  #[ORM\Column(name: 'export_url', length: 512, nullable: true)]
+  #[JMSA\Type('string')]
+  private ?string $exportUrl = null;
 
   public function __construct()
   {
@@ -833,6 +845,30 @@ class StudyArea implements Stringable, IdInterface
   public function setDotronConfig(?array $dotronConfig): self
   {
     $this->dotronConfig = $dotronConfig;
+
+    return $this;
+  }
+
+  public function isUrlExportEnabled(): bool
+  {
+    return $this->urlExportEnabled;
+  }
+
+  public function setUrlExportEnabled(bool $urlExportEnabled): self
+  {
+    $this->urlExportEnabled = $urlExportEnabled;
+
+    return $this;
+  }
+
+  public function getExportUrl(): ?string
+  {
+    return $this->exportUrl;
+  }
+
+  public function setExportUrl(?string $exportUrl): self
+  {
+    $this->exportUrl = StringHelper::emptyToNull($exportUrl);
 
     return $this;
   }

--- a/src/Export/Provider/LinkedSimpleNodeProvider.php
+++ b/src/Export/Provider/LinkedSimpleNodeProvider.php
@@ -70,6 +70,9 @@ class LinkedSimpleNodeProvider implements ProviderInterface
 
     return sprintf(<<<'EOT'
 {
+    "id": "<studyarea-id>",
+    "date_created": "<studyarea-date-created>",
+    "last_updated": "<studyarea-date-last-updated>",
     "nodes": [
         {
             "instance": "<concept-instance>",
@@ -249,6 +252,9 @@ EOT,
     $serializationContext->setSerializeNull(true);
     $json = $this->serializer->serialize(
       [
+        'id'                          => $studyArea->getId(),
+        'date_created'                => $studyArea->getCreatedAt(),
+        'last_updated'                => $studyArea->getLastUpdated(),
         'nodes' => array_map(fn (Concept $concept) => [
           'instance'       => $concept->isInstance(),
           'label'          => $concept->getName(),

--- a/src/Form/Data/DownloadType.php
+++ b/src/Form/Data/DownloadType.php
@@ -2,6 +2,7 @@
 
 namespace App\Form\Data;
 
+use App\Entity\StudyArea;
 use App\Export\ExportService;
 use App\Form\Type\SingleSubmitType;
 use Override;
@@ -45,5 +46,16 @@ class DownloadType extends AbstractType
         'target' => '_blank',
       ],
     ]);
+
+    $resolver->setNormalizer('attr', function (OptionsResolver $optionsResolver, $attr) {
+      /** @var StudyArea $studyArea */
+      $studyArea = $optionsResolver->offsetGet('current_study_area');
+      if ($studyArea->isUrlExportEnabled() && $studyArea->getExportUrl() !== null) {
+        $attr['target'] = '_self';
+      } else {
+        $attr['target'] = '_blank';
+      }
+      return $attr;
+    });
   }
 }

--- a/src/Form/Data/DownloadType.php
+++ b/src/Form/Data/DownloadType.php
@@ -39,12 +39,15 @@ class DownloadType extends AbstractType
   }
 
   #[Override]
-  public function configureOptions(OptionsResolver $resolver): void
-  {
-    $resolver->setDefaults([
-      'attr' => [
-        'target' => '_blank',
-      ],
+  public function configureOptions(OptionsResolver $resolver)
+  {  
+    $resolver
+      ->setRequired('current_study_area')
+      ->setAllowedTypes('current_study_area', StudyArea::class)
+      ->setDefaults([
+        'attr' => [
+            'target' => '_blank',
+        ],
     ]);
 
     $resolver->setNormalizer('attr', function (OptionsResolver $optionsResolver, $attr) {

--- a/src/Form/StudyArea/EditStudyAreaType.php
+++ b/src/Form/StudyArea/EditStudyAreaType.php
@@ -126,6 +126,20 @@ class EditStudyAreaType extends AbstractType
         'label'    => 'study-area.dotron',
         'help'     => 'study-area.dotron-help',
       ]);
+    
+    if ($this->security->isGranted('ROLE_SUPER_ADMIN')) {
+      $builder
+        ->add('urlExportEnabled', CheckboxType::class, [            
+          'label'    => 'study-area.url-export-enabled',
+          'help'     => 'study-area.url-export-enabled-help',
+          'required' => false,
+        ])
+        ->add('exportUrl', TextType::class, [
+          'label'    => 'study-area.export-url',
+          'help'     => 'study-area.export-url-help',
+          'required' => false,
+        ]);
+    }
 
     if ($studyArea->getId()) {
       $builder

--- a/templates/study_area/edit.html.twig
+++ b/templates/study_area/edit.html.twig
@@ -115,6 +115,18 @@
               }
             })
             .trigger('change');
+
+        $('#{{ form.urlExportEnabled.vars.id }}')
+            .on('change', function(){
+              var urlExportEnabled = $(this).is(':checked');
+              var $exportUrlForm = $('#{{ form.exportUrl.vars.id }}').closest('.form-group');
+              if (urlExportEnabled) {
+                $exportUrlForm.show();
+              } else {
+                $exportUrlForm.hide();
+              }
+            })
+            .trigger('change');
       });
     </script>
 {% endblock %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -232,6 +232,8 @@ data:
     In order to select an existing area, you need to have write right, and review mode must be disabled.
     You can either select a concept/instance subset, or tick "Select all" to duplicate all concepts/instances.
     Note that other elements will always be duplicated fully (e.g. contributors, external resources).'
+  export-to-url-error: 'You get this message because your enabled export to URL in your study area. The system could not export the current study area to'
+  export-to-url-success: 'Because you enabled export to URL, this study area was exported successfully to'  
   json-file: 'JSON data file'
   json-incorrect: 'JSON data incorrect! %message%'
   json-uploaded: 'JSON data successfully imported!'
@@ -662,6 +664,8 @@ study-area:
   dotron-help: "When enabled, Dotron visualization will be used."
   edit-title: 'Edit study area "%item%"'
   existing: 'Existing study area'
+  export-url: 'Export URL'
+  export-url-help: 'URL end point to export studyarea.'
   field-configuration:
     text: >-
       Here you can update the object and field naming for the current study area.
@@ -756,6 +760,8 @@ study-area:
   unfreeze-text: 'Are you sure you want to unfreeze the study area "%item%"? This could lead to data loss for users of this study area when data is edited, please use this feature responsibly!'
   unfreeze-succeeded: 'Study area "%item%" has been unfrozen successfully.'
   updated: 'Study area "%item%" has been successfully updated.'
+  url-export-enabled: 'Export to external URL'
+  url-export-enabled-help: 'Enabling this makes it possible to export this study area to given URL endpoint'
 
 relation-type:
   _name: 'Relation type'


### PR DESCRIPTION
This PR supports exporting study area content to an external URL via a PUT method. The following conditions have to be met to support exporting study area content to external URL.

- The Export to study area must be enabled
- The Link of the external URL should be provided