### PR TITLE
Corrected route name and template

### DIFF
--- a/src/Controller/ContributorController.php
+++ b/src/Controller/ContributorController.php
@@ -23,7 +23,7 @@ class ContributorController extends AbstractController
 {
   #[Route('/add')]
   #[IsGranted(StudyAreaVoter::EDIT, subject: 'requestStudyArea')]
-  #[DenyOnFrozenStudyArea(route: 'app_contributor_add', subject: 'requestStudyArea')]
+  #[DenyOnFrozenStudyArea(route: 'app_contributor_list', subject: 'requestStudyArea')]
   public function add(
     Request $request, RequestStudyArea $requestStudyArea, ReviewService $reviewService, TranslatorInterface $trans): Response
   {


### PR DESCRIPTION
The `ContributorController::add` controller returns the rendered `list.html.twig` template which throws a `RuntimeError` that the _studyArea_ variable does not exist. 