### PR TITLE
LOCK_DSN for semaphore requires php extension sysvsem

### DIFF
--- a/docker/ltb/Dockerfile
+++ b/docker/ltb/Dockerfile
@@ -67,6 +67,7 @@ RUN docker-php-ext-install gd
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install sockets
 RUN docker-php-ext-install xsl
+RUN docker-php-ext-install sysvsem
 RUN pecl install apcu && docker-php-ext-enable apcu
 RUN pecl install imagick && docker-php-ext-enable imagick
 


### PR DESCRIPTION
This pull request adds a Docker `RUN` instruction to install the _sysvsem_ PHP extension.

The controller `App\Controller\LatexController::renderLatex` uses Symfony’s rate limiter component to control the number of requests that generate an image for a LaTeX expression. By default, the rate limiter’s lock component is configured to use the semaphore store, which requires the _sysvsem_ PHP extension. This requirement is checked at runtime, throwing an exception if not installed.

> NOTE: If the `LOCK_DSN` in the application’s .env file(s) is configured to use a store other than semaphore, the _sysvsem_ extension is no longer required.

<img width="960" height="528" alt="Screenshot From 2025-08-09 12-26-52" src="https://github.com/user-attachments/assets/9e8d842b-a566-443a-8cf3-f4398aa69488" />

_Image 1: The exception shown in Firefox Network Developer Tools, when Docker container  is built without sysvsem extension & LOCK_DSN is configured to use the semaphore store._
