### PR TITLE
Install `texlive-fonts-extra` Debian package

### DIFF
--- a/docker/ltb/Dockerfile
+++ b/docker/ltb/Dockerfile
@@ -19,7 +19,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     ## Imagick
       imagemagick libmagickwand-dev libmagickcore-dev \
     # Latex
-      texlive-base texlive-latex-base texlive-latex-extra texlive-fonts-recommended poppler-utils \
+      texlive-base texlive-latex-base texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra poppler-utils \
     # Pandoc
       pandoc \
     # Python build dependencies \


### PR DESCRIPTION
This pull request installs the Debian package `texlive-fonts-extra` when building the container to resolve an error that occurs during _printing_.

## Error Description

The error displayed in the browser and logs indicates that support for the Droid Sans font is missing. From the little research I’ve done, it appears that the Debian TeX Live maintainers once bundled the fonts with `texlive-latex-extra` but later split them into separate packages: `texlive-fonts-recommended` and `texlive-fonts-extra`.

<img width="1296" height="533" alt="texlive-fonts-extra" src="https://github.com/user-attachments/assets/42adb7a3-8150-428b-a47b-94fdae491dbb" />

_Image 1:  Error displayed in web browser_

## Alternative Solution

Change  [templates/concept_print/base/concept_print.tex.twig](https://github.com/utwente/living-textbook/blob/729e19ac2890ac446600e6bb3f892e6b9023d7a7/templates/concept_print/base/concept_print.tex.twig#L37) to a font supported by the already installed `texlive-fonts-recommended`. 

## Additional Resources

- [texlive-fonts-recommend file list](https://packages.debian.org/bookworm/all/texlive-fonts-recommended/filelist)
- [texlive-fonts-extra file list](https://packages.debian.org/bookworm/all/texlive-fonts-extra/filelist)
